### PR TITLE
Switch fonts to system defaults

### DIFF
--- a/static/css/theme-override.css
+++ b/static/css/theme-override.css
@@ -1,1 +1,39 @@
-/**/
+html {
+	font-family: system-ui,
+				 "-apple-system",
+				 "BlinkMacSystemFont",
+                 "Segoe UI",
+                 "Roboto",
+                 "Helvetica Neue",
+                 "Ubuntu",
+                 "Arial",
+                 sans-serif;
+}
+
+@supports (font-variation-settings: normal) {
+	html {
+		font-family: system-ui,
+					 "-apple-system",
+					 "BlinkMacSystemFont",
+	                 "Segoe UI",
+	                 "Roboto",
+	                 "Helvetica Neue",
+	                 "Ubuntu",
+	                 "Arial",
+	                 sans-serif;
+	}
+}
+
+code {
+	font-family: ui-monospace,
+	             Menlo, Monaco,
+	             "Cascadia Mono", "Segoe UI Mono",
+	             "Roboto Mono",
+	             "Oxygen Mono",
+	             "Ubuntu Monospace",
+	             "Source Code Pro",
+	             "Fira Mono",
+	             "Droid Sans Mono",
+	             "Courier New",
+	             monospace;
+}


### PR DESCRIPTION
Fixes #3 

Switches the fonts to system UI, to avoid extra load times and complexity.

```css
	font-family: system-ui,
                 "-apple-system",
                 "BlinkMacSystemFont",
                 "Segoe UI",
                 "Roboto",
                 "Helvetica Neue",
                 "Ubuntu",
                 "Arial",
                 sans-serif;
```

```css
	font-family: ui-monospace,
	             Menlo, Monaco,
	             "Cascadia Mono", "Segoe UI Mono",
	             "Roboto Mono",
	             "Oxygen Mono",
	             "Ubuntu Monospace",
	             "Source Code Pro",
	             "Fira Mono",
	             "Droid Sans Mono",
	             "Courier New",
	             monospace;
```